### PR TITLE
💄 Limpiar menú

### DIFF
--- a/cerebros/archivo.js
+++ b/cerebros/archivo.js
@@ -2,7 +2,6 @@ import { defineStore } from 'pinia';
 
 export const usarArchivo = defineStore('archivo', {
   state: () => ({
-    paginaActual: null,
     obrasPorPagina: 25,
   }),
 });

--- a/components/Galeria/index.vue
+++ b/components/Galeria/index.vue
@@ -24,7 +24,6 @@ const props = defineProps({
  */
 const ruta = useRoute();
 const datos = ref(null);
-const numeroPaginaActual = ref(0);
 const respuesta = await obtenerDatos(props.coleccion, nombrePorSlug(props.coleccion, ruta.params.slug));
 const numeroPaginas = computed(() => {
   if (datos.value && datos.value.obras_func) {
@@ -47,10 +46,6 @@ const { data, pending, refresh } = obtenerDatosAsinc(
   obrasPorSlug(props.coleccion, ruta.params.slug, props.enTablaRelacional, ruta.query.pagina)
 );
 
-onMounted(() => {
-  cerebroArchivo.paginaActual = props.paginaActual;
-});
-
 watch(data, (datosObras) => {
   // // Extraer las obras de colección directamente o de la tabla relacional.
   obras.value = !props.enTablaRelacional
@@ -64,7 +59,7 @@ function actualizarPagina(numeroPagina) {
 </script>
 
 <template>
-  <h1>{{ `${singular || props.paginaActual} - ${datos.nombre}` }}</h1>
+  <h1>{{ `${singular} - ${datos.nombre}` }}</h1>
   <Cargador v-if="pending" />
   <GraficaContador :numeroObras="datos.obras_func.count" />
   <GaleriaMosaico :obras="obras" />

--- a/components/Menu/Buscador.vue
+++ b/components/Menu/Buscador.vue
@@ -1,14 +1,10 @@
 <script setup>
 import { usarArchivo } from '~~/cerebros/archivo';
-import { extraerPrimeraLetra, gql } from '~~/utilidades/ayudas';
 
 const cerebroArchivo = usarArchivo();
-const inicialSeleccionada = ref('');
-const autores = ref(null);
-const inicialesAutores = new Set();
 
 const opciones = [
-  { nombre: 'Autores', slug: 'autores', iniciales: inicialesAutores },
+  { nombre: 'Autores', slug: 'autores' },
   { nombre: 'Categorías', slug: 'categorias' },
   { nombre: 'Escenarios', slug: 'escenarios' },
   { nombre: 'Técnicas', slug: 'tecnicas' },
@@ -28,33 +24,13 @@ const opciones = [
 ];
 
 const paginaActual = computed(() => cerebroArchivo.paginaActual);
-
-const ArchivoMenuBuscador = gql`
-  query {
-    autores(limit: -1, sort: ["apellido"]) {
-      apellido
-    }
-  }
-`;
-const { autores: datosAutores } = await obtenerDatos('archivoMenuBuscador', ArchivoMenuBuscador);
-
-datosAutores.forEach((autor) => {
-  const inicial = extraerPrimeraLetra(autor.apellido).toUpperCase();
-  inicialesAutores.add(inicial);
-});
-
-autores.value = Array.from(inicialesAutores).sort();
 </script>
 
 <template>
-  <div id="contenedorBuscador">
-    <NuxtLink :to="'/'">
-      <h2 class="logo-texto">ARCA</h2>
-    </NuxtLink>
+  <aside id="contenedorBuscador">
+    <h2 class="nombreProyecto"><NuxtLink :to="'/'">ARCA</NuxtLink></h2>
 
-    <Buscador />
-
-    <nav class="opcionesBuscador">
+    <nav id="opciones">
       <ul class="listaMenu">
         <li
           v-for="opcion in opciones"
@@ -63,29 +39,14 @@ autores.value = Array.from(inicialesAutores).sort();
           :class="paginaActual === opcion.nombre ? 'activo' : ''"
         >
           <NuxtLink class="coleccion" :to="`/archivo/${opcion.slug}`">{{ opcion.nombre }}</NuxtLink>
-
-          <ul v-if="opcion.iniciales" class="iniciales">
-            <li
-              v-for="(inicial, i) in opcion.iniciales"
-              :key="`inicial${i}`"
-              :class="`inicial ${inicialSeleccionada === inicial ? 'activo' : ''}`"
-              @click="elegirInicial(inicial)"
-            >
-              {{ inicial }}
-            </li>
-          </ul>
         </li>
       </ul>
     </nav>
-  </div>
+  </aside>
 </template>
 
 <style lang="scss" scoped>
 @use 'sass:color';
-
-a {
-  font-family: var(--fuenteMenu);
-}
 
 #contenedorBuscador {
   background-color: var(--verdeEsmeralda);
@@ -96,31 +57,32 @@ a {
   height: 100vh;
 }
 
-.logo-texto {
-  font-family: var(--fuentePrincipal);
-  margin: 2.5vw;
-  margin-bottom: 2vw;
-  margin-top: 3vw;
-  color: var(--mediana);
-  letter-spacing: 0.15em;
-  font-size: 2em;
-  overflow: hidden;
+.nombreProyecto {
+  padding: 1.3em 0 1em 0;
+
+  a {
+    font-family: var(--fuentePrincipal);
+    font-weight: bold;
+    margin-left: 1.3em;
+    color: var(--mediana);
+    letter-spacing: 0.15em;
+    font-size: 1.35em;
+    overflow: hidden;
+  }
 }
 
-.opcionesBuscador {
+#opciones {
   text-transform: uppercase;
-  margin-top: 2em;
+  margin: 0 0 3em 2.5em;
   padding: 0;
-}
-
-.listaMenu {
-  margin-left: 2.5em;
-  //  letter-spacing: -.01rem;
   position: relative;
+
+  li {
+    padding: 0;
+  }
 }
 
 .opcion {
-  // height: 1em;
   font-size: 0.9em;
   margin-top: 0.9em;
   overflow: hidden;
@@ -131,53 +93,21 @@ a {
     .iniciales {
       height: auto;
     }
-  }
 
-  // &::before {
-  //   content: '';
-  //   width: 3px;
-  //   height: 3px;
-  //   border-radius: 50%;
-  //   display: block;
-  //   background-color: var(--dolor);
-  //   position: absolute;
-  //   left: 0.3em;
-  //   top: 0.5em;
-  //   z-index: 9;
-  // }
+    a {
+      color: darken($mediana, 20%);
+    }
+  }
 
   a,
   a:link {
     color: var(--mediana);
+    font-family: var(--fuenteMenu);
+    font-weight: bold;
 
     &:hover {
       color: darken($mediana, 10%);
     }
   }
-}
-
-.iniciales {
-  font-size: 1em;
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0;
-  height: 0;
-  transition: all 0.25s ease-out;
-
-  .inicial {
-    cursor: pointer;
-    font-size: 0.8em;
-    margin: 0;
-    padding: 0 0.3em 0 0;
-
-    &.activo {
-      font-weight: bold;
-    }
-  }
-}
-
-.activo .coleccion,
-.router-link-exact-active {
-  font-weight: bold;
 }
 </style>

--- a/components/Menu/Buscador.vue
+++ b/components/Menu/Buscador.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
-
-const cerebroArchivo = usarArchivo();
+const ruta = useRoute();
 
 const opciones = [
   { nombre: 'Autores', slug: 'autores' },
@@ -23,7 +21,16 @@ const opciones = [
   { nombre: 'Rostros', slug: 'rostros' },
 ];
 
-const paginaActual = computed(() => cerebroArchivo.paginaActual);
+const esRutaActual = (slug) => {
+  const partes = ruta.path.split('/');
+
+  if (partes[2].includes('categorias')) {
+    return slug === 'categorias';
+  } else if (partes[2] === 'paises') {
+    return slug === 'ubicaciones';
+  }
+  return partes.includes(slug);
+};
 </script>
 
 <template>
@@ -36,7 +43,7 @@ const paginaActual = computed(() => cerebroArchivo.paginaActual);
           v-for="opcion in opciones"
           :key="opcion.slug"
           class="opcion"
-          :class="paginaActual === opcion.nombre ? 'activo' : ''"
+          :class="esRutaActual(opcion.slug) ? 'activo' : ''"
         >
           <NuxtLink class="coleccion" :to="`/archivo/${opcion.slug}`">{{ opcion.nombre }}</NuxtLink>
         </li>

--- a/pages/archivo/autores/[id].vue
+++ b/pages/archivo/autores/[id].vue
@@ -13,7 +13,7 @@ query {
     nombre
     apellido
     biografia
-     obras_func {
+    obras_func {
         count
       }
   }
@@ -51,8 +51,6 @@ useHead(
  */
 const obras = ref([]);
 const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Autores';
 
 const ObrasAutor = gql`
 query {

--- a/pages/archivo/autores/index.vue
+++ b/pages/archivo/autores/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const autores = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Autores';
 
 const Autores = gql`
   query {

--- a/pages/archivo/caracteristicas-particulares/[slug].vue
+++ b/pages/archivo/caracteristicas-particulares/[slug].vue
@@ -3,10 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria
-    coleccion="caracteristicas"
-    paginaActual="Características Particulares"
-    singular="Característica Particular"
-    :enTablaRelacional="true"
-  />
+  <Galeria coleccion="caracteristicas" singular="Característica Particular" :enTablaRelacional="true" />
 </template>

--- a/pages/archivo/caracteristicas-particulares/index.vue
+++ b/pages/archivo/caracteristicas-particulares/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const caracteristicas = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Características Particulares';
 
 const ObrasPorCaracteristicas = gql`
   query {
@@ -31,13 +27,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 <template>
   <h1>Características Particulares</h1>
   <Cargador v-if="pending" />
-  <!--<ul v-else>
-    <li v-for="caracteristica in caracteristicas" :key="caracteristica.slug">
-      <NuxtLink :to="`/archivo/caracteristicas-particulares/${caracteristica.slug}`"
-        >{{ caracteristica.nombre }} ({{ caracteristica.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
--->
   <GraficaColombinas v-else :datos="caracteristicas" coleccion="caracteristicas-particulares" />
 </template>

--- a/pages/archivo/cartela-filacteria/[slug].vue
+++ b/pages/archivo/cartela-filacteria/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="cartelas_filacterias" paginaActual="Cartela - Filacteria" />
+  <Galeria coleccion="cartelas_filacterias" singular="Cartela - Filacteria" />
 </template>

--- a/pages/archivo/cartela-filacteria/index.vue
+++ b/pages/archivo/cartela-filacteria/index.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const cartelaFilacteria = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Cartela - Filacteria';
-
 const ObrasPorCartela = gql`
   query {
     cartelas_filacterias(sort: ["nombre"], limit: -1) {
@@ -19,7 +14,7 @@ const ObrasPorCartela = gql`
   }
 `;
 
-const { data, error, pending } = obtenerDatosAsinc('obrasPorCartela', ObrasPorCartela);
+const { data, pending } = obtenerDatosAsinc('obrasPorCartela', ObrasPorCartela);
 
 watch(data, ({ cartelas_filacterias: datosCartelaFilacteria }) => {
   cartelaFilacteria.value = datosCartelaFilacteria;
@@ -31,13 +26,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 <template>
   <h1>Cartela - Filacteria</h1>
   <Cargador v-if="pending" />
-  <!--<ul v-else>
-    <li v-for="elemento in cartelaFilacteria" :key="elemento.slug">
-      <NuxtLink :to="`/archivo/cartela-filacteria/${elemento.slug}`">
-        {{ elemento.nombre }} ({{ elemento.obras_func.count }})
-      </NuxtLink>
-    </li>
-  </ul>
--->
   <GraficaColombinas v-else :datos="cartelaFilacteria" coleccion="cartela-filacteria" />
 </template>

--- a/pages/archivo/categorias[[numero]]/[id].vue
+++ b/pages/archivo/categorias[[numero]]/[id].vue
@@ -20,23 +20,11 @@ query {
 const respuesta = await obtenerDatos(`categorias${ruta.params.numero}-${ruta.params.id}`, Categoria);
 const datos = respuesta[llave];
 
-// useHead(
-//   elementosCabeza(
-//     {
-//       nombre: crearNombre(),
-//       descripcion: datosAutor.biografia,
-//     },
-//     ruta.path
-//   )
-// ); // SEO
-
 /**
  * Operaciones en el cliente
  */
 const obras = ref([]);
 const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Categorías';
 
 const ObrasCategoria = gql`
 query {
@@ -60,14 +48,10 @@ query {
 }
 `;
 
-const { data, error, pending } = obtenerDatosAsinc(`obrasCategoria${datos.id}`, ObrasCategoria);
+const { data, pending } = obtenerDatosAsinc(`obrasCategoria${datos.id}`, ObrasCategoria);
 
 watch(data, (respuesta) => {
   obras.value = respuesta[llave].obras;
-});
-
-watch(error, (errores) => {
-  console.error(errores);
 });
 
 definePageMeta({ layout: 'con-buscador', keepalive: true });

--- a/pages/archivo/categorias[[numero]]/index.vue
+++ b/pages/archivo/categorias[[numero]]/index.vue
@@ -1,9 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { aplanarCategorias, gql } from '~~/utilidades/ayudas';
 
 const categorias = ref([]);
-const cerebroArchivo = usarArchivo();
 
 const camposCategoria = (nivel, respuesta) => {
   if (nivel === 1) {
@@ -44,7 +42,6 @@ watch(data, ({ categorias1 }) => {
   });
 });
 
-cerebroArchivo.paginaActual = 'Categorías';
 definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 

--- a/pages/archivo/descriptores/[slug].vue
+++ b/pages/archivo/descriptores/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="descriptores" paginaActual="Descriptores" singular="Descriptor" :enTablaRelacional="true" />
+  <Galeria coleccion="descriptores" singular="Descriptor" :enTablaRelacional="true" />
 </template>

--- a/pages/archivo/descriptores/index.vue
+++ b/pages/archivo/descriptores/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const descriptores = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Descriptores';
 
 const ObrasPorDescriptores = gql`
   query {

--- a/pages/archivo/donantes/[slug].vue
+++ b/pages/archivo/donantes/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="donantes" paginaActual="Donantes" singular="Donante" />
+  <Galeria coleccion="donantes" singular="Donante" />
 </template>

--- a/pages/archivo/donantes/index.vue
+++ b/pages/archivo/donantes/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const donantes = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Donantes';
 
 const ObrasPorDonantes = gql`
   query {
@@ -31,13 +27,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 <template>
   <h1>Donantes</h1>
   <Cargador v-if="pending" />
-  <!--<ul v-else>
-    <li v-for="donante in donantes" :key="donante.slug">
-      <NuxtLink :to="`/archivo/donantes/${donante.slug}`"
-        >{{ donante.nombre }} ({{ donante.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
--->
   <GraficaColombinas v-else :datos="donantes" coleccion="donantes" />
 </template>

--- a/pages/archivo/escenarios/[slug].vue
+++ b/pages/archivo/escenarios/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="escenarios" :enTablaRelacional="true" paginaActual="Escenarios" singular="Escenario" />
+  <Galeria coleccion="escenarios" :enTablaRelacional="true" singular="Escenario" />
 </template>

--- a/pages/archivo/escenarios/index.vue
+++ b/pages/archivo/escenarios/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const escenarios = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Escenarios';
 
 const ObrasPorEscenarios = gql`
   query {
@@ -31,13 +27,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 <template>
   <h1>Escenarios</h1>
   <Cargador v-if="pending" />
-  <!--  <ul v-else>
-    <li v-for="escenario in escenarios" :key="escenario.slug">
-      <NuxtLink :to="`/archivo/escenarios/${escenario.slug}`"
-        >{{ escenario.nombre }} ({{ escenario.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
-S-->
   <GraficaColombinas v-else :datos="escenarios" coleccion="escenarios" />
 </template>

--- a/pages/archivo/fisiognomica-imagen/index.vue
+++ b/pages/archivo/fisiognomica-imagen/index.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const fisiognomicaImagen = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Fisiognómica Imagen';
-
 const ObrasPorFisiognomicaImagen = gql`
   query {
     fisiognomicas_imagen(sort: ["nombre"], limit: -1) {

--- a/pages/archivo/fisiognomica/[slug].vue
+++ b/pages/archivo/fisiognomica/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="fisiognomicas" paginaActual="Fisiognómica" />
+  <Galeria coleccion="fisiognomicas" singular="Fisiognómica" />
 </template>

--- a/pages/archivo/fisiognomica/index.vue
+++ b/pages/archivo/fisiognomica/index.vue
@@ -1,13 +1,9 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const fisiognomica = ref([]);
-const cerebroArchivo = usarArchivo();
 const ruta = useRoute();
 const titulo = 'Fisiognómica';
-
-cerebroArchivo.paginaActual = titulo;
 
 const ObrasPorFisiognomica = gql`
   query {
@@ -31,13 +27,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 
 <template>
   <h1>{{ titulo }}</h1>
-  <!--<ul class="opciones">
-    <li v-for="elemento in fisiognomica" :key="elemento.slug">
-      <NuxtLink :to="`/archivo/fisiognomica/${elemento.slug}`"
-        >{{ elemento.nombre }} ({{ elemento.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
--->
   <GraficaColombinas :datos="fisiognomica" coleccion="fisiognomica" />
 </template>

--- a/pages/archivo/gestos/[slug].vue
+++ b/pages/archivo/gestos/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="gestos" :enTablaRelacional="true" paginaActual="Gestos" singular="Gesto" />
+  <Galeria coleccion="gestos" :enTablaRelacional="true" singular="Gesto" />
 </template>

--- a/pages/archivo/gestos/index.vue
+++ b/pages/archivo/gestos/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const gestos = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Gestos';
 
 const ObrasPorGestos = gql`
   query {

--- a/pages/archivo/index.vue
+++ b/pages/archivo/index.vue
@@ -1,8 +1,6 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
-const cerebroArchivo = usarArchivo();
 const ruta = useRoute();
 
 const { paginas } = await obtenerDatos(
@@ -27,7 +25,6 @@ useHead(elementosCabeza(paginas[0] ? paginas[0] : {}, ruta.path));
 
 const pagina = ref(null);
 pagina.value = paginas[0];
-cerebroArchivo.paginaActual = '';
 
 // Nuxt normaliza los nombres de "layouts" a kebab-case.
 definePageMeta({ layout: 'con-buscador', keepalive: true });

--- a/pages/archivo/objetos/[slug].vue
+++ b/pages/archivo/objetos/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="objetos" :enTablaRelacional="true" paginaActual="Objetos" singular="Objeto" />
+  <Galeria coleccion="objetos" :enTablaRelacional="true" singular="Objeto" />
 </template>

--- a/pages/archivo/objetos/index.vue
+++ b/pages/archivo/objetos/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const objetos = ref([]);
-const cerebroArchivo = usarArchivo();
-cerebroArchivo.paginaActual = 'Objetos';
-
 const ObrasPorObjetos = gql`
   query {
     objetos(sort: ["nombre"], limit: -1) {
@@ -26,11 +22,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 
 <template>
   <h1>Objetos</h1>
-  <!--<ul class="opciones">
-    <li v-for="objeto in objetos" :key="objeto.slug">
-      <NuxtLink :to="`/archivo/objetos/${objeto.slug}`">{{ objeto.nombre }} ({{ objeto.obras_func.count }})</NuxtLink>
-    </li>
-  </ul>
--->
   <GraficaColombinas :datos="objetos" coleccion="objetos" />
 </template>

--- a/pages/archivo/obras/[registro].vue
+++ b/pages/archivo/obras/[registro].vue
@@ -1,16 +1,9 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql, urlImagen } from '~~/utilidades/ayudas';
 
 const cargando = ref(true);
 const obra = ref(null);
-const cerebroArchivo = usarArchivo();
 const ruta = useRoute();
-
-// Para cambiar de pestaña y mostrar otros datos
-const pestana = ref('');
-
-cerebroArchivo.paginaActual = 'Obras';
 
 const Obra = gql`
   query {

--- a/pages/archivo/obras/index.vue
+++ b/pages/archivo/obras/index.vue
@@ -1,13 +1,8 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const cargando = ref(true);
 const total = ref(0);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Obras';
-
 const Obras = gql`
   query {
     obras_aggregated {

--- a/pages/archivo/paises/[slug].vue
+++ b/pages/archivo/paises/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="paises" paginaActual="Ubicaciones" singular="País" />
+  <Galeria coleccion="paises" singular="País" />
 </template>

--- a/pages/archivo/personajes/[slug].vue
+++ b/pages/archivo/personajes/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="personajes" :enTablaRelacional="true" paginaActual="Personajes" singular="Personaje" />
+  <Galeria coleccion="personajes" :enTablaRelacional="true" singular="Personaje" />
 </template>

--- a/pages/archivo/personajes/index.vue
+++ b/pages/archivo/personajes/index.vue
@@ -1,11 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const personajes = ref([]);
-const cerebroArchivo = usarArchivo();
-cerebroArchivo.paginaActual = 'Personajes';
-
 const ObrasPorPersonajes = gql`
   query {
     personajes(sort: ["nombre"], limit: -1) {
@@ -26,13 +22,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 
 <template>
   <h1>Personajes</h1>
-  <!--<ul class="opciones">
-    <li v-for="personaje in personajes" :key="personaje.slug">
-      <NuxtLink :to="`/archivo/personajes/${personaje.slug}`">
-        {{ personaje.nombre }} ({{ personaje.obras_func.count }})
-      </NuxtLink>
-    </li>
-  </ul>
--->
   <GraficaColombinas :datos="personajes" coleccion="personajes" />
 </template>

--- a/pages/archivo/relatos-visuales/[slug].vue
+++ b/pages/archivo/relatos-visuales/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="relatos_visuales" paginaActual="Relatos Visuales" singular="Relato Visual" />
+  <Galeria coleccion="relatos_visuales" singular="Relato Visual" />
 </template>

--- a/pages/archivo/relatos-visuales/index.vue
+++ b/pages/archivo/relatos-visuales/index.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const relatos = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Relatos Visuales';
-
 const ObrasPorRelatos = gql`
   query {
     relatos_visuales(sort: ["nombre"], limit: -1) {
@@ -27,14 +22,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 
 <template>
   <h1>Relatos Visuales</h1>
-
-  <!--<ul class="opciones">
-    <li v-for="relato in relatos" :key="relato.slug">
-      <NuxtLink :to="`/archivo/relatos-visuales/${relato.slug}`"
-        >{{ relato.nombre }} ({{ relato.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
-  -->
   <GraficaColombinas :datos="relatos" coleccion="relatos-visuales" />
 </template>

--- a/pages/archivo/rostros/[slug].vue
+++ b/pages/archivo/rostros/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="rostros" paginaActual="Rostros" singular="Rostro" />
+  <Galeria coleccion="rostros" singular="Rostro" />
 </template>

--- a/pages/archivo/rostros/index.vue
+++ b/pages/archivo/rostros/index.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const rostros = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Rostros';
-
 const ObrasPorRostros = gql`
   query {
     rostros(sort: ["nombre"], limit: -1) {
@@ -27,11 +22,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 
 <template>
   <h1>Rostros</h1>
-  <!--<ul class="opciones">
-    <li v-for="rostro in rostros" :key="rostro.slug">
-      <NuxtLink :to="`/archivo/rostros/${rostro.slug}`">{{ rostro.nombre }} ({{ rostro.obras_func.count }})</NuxtLink>
-    </li>
-  </ul>
-  -->
   <GraficaColombinas :datos="rostros" coleccion="rostros" />
 </template>

--- a/pages/archivo/simbolos/[slug].vue
+++ b/pages/archivo/simbolos/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="simbolos" paginaActual="Símbolos" singular="Símbolo" :enTablaRelacional="true" />
+  <Galeria coleccion="simbolos" singular="Símbolo" :enTablaRelacional="true" />
 </template>

--- a/pages/archivo/simbolos/index.vue
+++ b/pages/archivo/simbolos/index.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const simbolos = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Símbolos';
-
 const ObrasPorSimbolos = gql`
   query {
     simbolos(sort: ["nombre"], limit: -1) {
@@ -31,13 +26,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 <template>
   <h1>Simbolos</h1>
   <Cargador v-if="pending" />
-  <!--<ul v-else>
-    <li v-for="simbolo in simbolos" :key="simbolo.slug">
-      <NuxtLink :to="`/archivo/simbolos/${simbolo.slug}`"
-        >{{ simbolo.nombre }} ({{ simbolo.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
--->
   <GraficaColombinas v-else :datos="simbolos" coleccion="simbolos" />
 </template>

--- a/pages/archivo/tecnicas/[slug].vue
+++ b/pages/archivo/tecnicas/[slug].vue
@@ -3,5 +3,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 </script>
 
 <template>
-  <Galeria coleccion="tecnicas" :enTablaRelacional="true" paginaActual="Técnicas" singular="Técnica" />
+  <Galeria coleccion="tecnicas" :enTablaRelacional="true" singular="Técnica" />
 </template>

--- a/pages/archivo/tecnicas/index.vue
+++ b/pages/archivo/tecnicas/index.vue
@@ -1,12 +1,7 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql } from '~~/utilidades/ayudas';
 
 const tecnicas = ref([]);
-const cerebroArchivo = usarArchivo();
-
-cerebroArchivo.paginaActual = 'Técnicas';
-
 const ObrasPorTecnicas = gql`
   query {
     tecnicas(sort: ["nombre"], limit: -1) {
@@ -27,13 +22,5 @@ definePageMeta({ layout: 'con-buscador', keepalive: true });
 
 <template>
   <h1>Técnicas</h1>
-  <!--<ul class="opciones">
-  <li v-for="tecnica in tecnicas" :key="tecnica.slug">
-      <NuxtLink :to="`/archivo/tecnicas/${tecnica.slug}`"
-        >{{ tecnica.nombre }} ({{ tecnica.obras_func.count }})</NuxtLink
-      >
-    </li>
-  </ul>
-  -->
   <GraficaColombinas :datos="tecnicas" coleccion="tecnicas" />
 </template>

--- a/pages/archivo/ubicaciones/[id].vue
+++ b/pages/archivo/ubicaciones/[id].vue
@@ -25,8 +25,6 @@ useHead(elementosCabeza(datosUbicacion, ruta.path)); // SEO
 const obras = ref([]);
 const cerebroArchivo = usarArchivo();
 
-cerebroArchivo.paginaActual = 'Ubicaciones';
-
 const ObrasUbicacion = gql`
 query {
   ubicaciones_by_id(id: ${ruta.params.id}) {

--- a/pages/archivo/ubicaciones/index.vue
+++ b/pages/archivo/ubicaciones/index.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { usarArchivo } from '~~/cerebros/archivo';
 import { gql, obtenerVariablesCSS } from '~~/utilidades/ayudas';
 import { escalaColores } from '@enflujo/alquimia';
 
@@ -7,15 +6,12 @@ const posiblesVistas = ['mapa', 'lista', 'colombinas'];
 let buscarColor;
 const ruta = useRoute();
 const enrutador = useRouter();
-const cerebroArchivo = usarArchivo();
 const datos = ref(null);
 const paises = ref(null);
 const ubicaciones = ref(null);
 const vista = ref('mapa');
 const valorMaximoObras = ref(0);
 const contenedorUbicaciones = ref(null);
-
-cerebroArchivo.paginaActual = 'Ubicaciones';
 
 definePageMeta({ layout: 'con-buscador', keepalive: true });
 


### PR DESCRIPTION
- El buscador va en otro lado.
- Resaltar la colección actual en el índice de cada colección y en sus páginas internas.
- Limpieza general del CSS.
- Lo de las iniciales en este menú ya no va.