### PR TITLE
✨ Agregar galería ordenada a obra individual

### DIFF
--- a/pages/archivo/obras/[registro].vue
+++ b/pages/archivo/obras/[registro].vue
@@ -25,6 +25,7 @@ const relacionadas = ref(null);
 const Obra = gql`
   query {
     obras(filter: { registro: { _eq: ${ruta.params.registro} } }, limit: 1) {
+      registro
       fecha_inicial
       fecha_final
       sintesis
@@ -167,6 +168,7 @@ definePageMeta({ layout: 'default', keepalive: true });
     </div>
 
     <div id="contenedorInfo">
+      <div class="datos"><span class="tituloDato">Registro:</span> {{ obra.registro }}</div>
       <div class="datos">
         <span class="tituloDato">Fecha:</span> {{ obra.fecha_inicial }}
         <span v-if="obra.fecha_final">- {{ obra.fecha_final }}</span>

--- a/pages/archivo/obras/[registro].vue
+++ b/pages/archivo/obras/[registro].vue
@@ -50,7 +50,7 @@ const Obra = gql`
       complejo_gestual { slug nombre }
 
       ciudad_origen { id nombre pais { slug nombre } }
-      ubicacion { id nombre ciudad { id nombre pais { slug nombre } } }
+      ubicacion { id nombre anotacion ciudad { id nombre pais { slug nombre } } }
 
       autores { autores_id { id nombre apellido } }
       gestos { gestos_id { slug nombre } }
@@ -102,7 +102,12 @@ watch(data, ({ obras }) => {
   }
 
   if (_obra.ubicacion) {
-    const ubicacion = [{ url: `/archivo/ubicaciones/${_obra.ubicacion.id}`, nombre: _obra.ubicacion.nombre }];
+    const ubicacion = [
+      {
+        url: `/archivo/ubicaciones/${_obra.ubicacion.id}`,
+        nombre: _obra.ubicacion.nombre + `${_obra.ubicacion.anotacion ? ' (' + _obra.ubicacion.anotacion + ')' : ''}`,
+      },
+    ];
 
     if (_obra.ubicacion.ciudad) {
       ubicacion.push({ url: `/archivo/ciudades/${_obra.ubicacion.ciudad.id}`, nombre: _obra.ubicacion.ciudad.nombre });
@@ -189,9 +194,7 @@ definePageMeta({ layout: 'default', keepalive: true });
         <span v-for="(lugar, i) in obra.ubicacion" :key="`ubicacion${lugar.url}`">
           <span v-if="i > 0" class="separador">|</span>
 
-          <NuxtLink :to="lugar.url">
-            {{ lugar.nombre }}
-          </NuxtLink>
+          <NuxtLink :to="lugar.url"> {{ lugar.nombre }} </NuxtLink>
         </span>
       </div>
 

--- a/pages/archivo/ubicaciones/[id].vue
+++ b/pages/archivo/ubicaciones/[id].vue
@@ -11,6 +11,7 @@ query {
   ubicaciones_by_id(id: ${ruta.params.id}) {
     id
     nombre
+    anotacion
   }
 }
 `;
@@ -57,6 +58,7 @@ definePageMeta({ layout: 'archivo', keepalive: true });
 
 <template>
   <h1>Ubicación: {{ datosUbicacion.nombre }}</h1>
+  <h2 v-if="datosUbicacion.anotacion">{{ datosUbicacion.anotacion }}</h2>
   <Cargador v-if="pending" />
   <GaleriaMosaico v-else :obras="obras" />
 </template>


### PR DESCRIPTION
- [x] Agregar a la página de obra individual la galería de obras relacionadas ordenadas por última(s) categoría(s).
- [x] Mostrar Anotación de ubicación en obra individual y en `archivo/ubicacion`